### PR TITLE
Update README for local setup and fix l10n description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Being a polyglot developer _and human_, I added multi-language support.
 
 The hero element is translated into the languages in which I feel like communicating.
 
-But rather than just show one, for the extremely rare case in which a user has more than one language support configured, it will invoke a carousel-like behaviour and rotate among only the languages the user has claimed to support. This is the case for my browser.
+On load, the page checks your browser's preferred language and shows only the matching translation (falling back to English if needed).
 
 # CSP and FSP
 
@@ -18,3 +18,13 @@ I also hardened the security by adding a CSP and a Feature Policy. I also added 
 
 Felt like adding [a Lighthouse audit](https://www.freecodecamp.org/news/how-to-use-lighthouse-in-github-actions/) to this as well,
 becuase code quality speaks, right?
+
+## Running Locally
+
+You can serve the site locally using Python's built-in HTTP server:
+
+```bash
+python3 -m http.server --directory .
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) in your browser.


### PR DESCRIPTION
## Summary
- fix description of language support
- add instructions for running the site locally using Python

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dc5b1ec64832a8cdf18f82a9526d9